### PR TITLE
[BUGFIX] Synchronize supported TYPO3 version with ext_emconf.php

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -32,7 +32,7 @@ $EM_CONF[$_EXTKEY] = [
     'author_company' => 'coding. powerful. systems. CPS GmbH',
     'constraints' => [
         'depends' => [
-            'typo3' => '11.5.0-13.0.99',
+            'typo3' => '11.5.0-12.4.99',
             'php' => '8.1.0-8.3.99',
         ],
     ],


### PR DESCRIPTION
This PR fixes the version range of supported TYPO3 versions in `ext_emconf.php`.