### PR TITLE
[FEATURE] Introduce recoverable transports

### DIFF
--- a/Classes/Mail/Transport/QueueableFileTransport.php
+++ b/Classes/Mail/Transport/QueueableFileTransport.php
@@ -42,7 +42,7 @@ use TYPO3\CMS\Core;
  * @author Elias Häußler <e.haeussler@familie-redlich.de>
  * @license GPL-2.0-or-later
  */
-final class QueueableFileTransport extends Core\Mail\FileSpool implements QueueableTransport
+final class QueueableFileTransport extends Core\Mail\FileSpool implements RecoverableTransport
 {
     public const FILE_SUFFIX_QUEUED = '.message';
     public const FILE_SUFFIX_SENDING = '.message.sending';

--- a/Classes/Mail/Transport/RecoverableTransport.php
+++ b/Classes/Mail/Transport/RecoverableTransport.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "mailqueue".
+ *
+ * Copyright (C) 2024 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\Typo3Mailqueue\Mail\Transport;
+
+/**
+ * RecoverableTransport
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+interface RecoverableTransport extends QueueableTransport
+{
+    public function recover(int $timeout = 900): void;
+}

--- a/README.md
+++ b/README.md
@@ -85,6 +85,19 @@ methods to enqueue and dequeue mails:
   with the difference that it only dequeues the given mail queue item and leaves the
   rest of the queue untouched.
 
+#### Recoverable transports
+
+Next to the `QueueableTransport` interface there exists an extended interface
+[`CPSIT\Typo3Mailqueue\Mail\Transport\RecoverableTransport`](Classes/Mail/Transport/RecoverableTransport.php).
+It allows to recover stuck mails with a configured recover timeout:
+
+* ```php
+  public function recover(int $timeout = 900): void
+  ```
+  Recovers mails that are enqueued for longer than the given timeout (in seconds) and
+  are in "sending" state. Recovering a mail resets their mail state from "sending" to
+  "queued". They will then be sent again on dequeue or when the mail queue is flushed.
+
 ### Backend module
 
 > [!NOTE]


### PR DESCRIPTION
This PR introduces a new `RecoverableTransport` interface. It can be used to mark transports as recoverable. When a transport is considered "recoverable", all mails in the queue can be restored from "sending" to "queued" state. This is already implemented for the `QueueableFileTransport`.