### PR TITLE
[TASK] View notice about required configuration in backend module

### DIFF
--- a/Classes/Controller/MailqueueModuleController.php
+++ b/Classes/Controller/MailqueueModuleController.php
@@ -65,6 +65,7 @@ final class MailqueueModuleController
         } else {
             $templateVariables = [
                 'unsupportedTransport' => $this->getTransportFromMailConfiguration(),
+                'typo3Version' => $this->typo3Version->getMajorVersion(),
             ];
         }
 

--- a/Classes/Exception/MailTransportIsNotConfigured.php
+++ b/Classes/Exception/MailTransportIsNotConfigured.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "mailqueue".
+ *
+ * Copyright (C) 2024 Elias Häußler <e.haeussler@familie-redlich.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace CPSIT\Typo3Mailqueue\Exception;
+
+/**
+ * MailTransportIsNotConfigured
+ *
+ * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @license GPL-2.0-or-later
+ */
+final class MailTransportIsNotConfigured extends Exception
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'No mail transport is configured. Please provide mail configuration in $GLOBALS[\'TYPO3_CONF_VARS\'][\'MAIL\'].',
+            1709803814,
+        );
+    }
+}

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -80,6 +80,16 @@
 				<source>The mail was successfully sent.</source>
 			</trans-unit>
 
+			<trans-unit id="unsupportedTransport.docs.text">
+				<source>Read the %s to learn more about mail spoolers in TYPO3.</source>
+			</trans-unit>
+			<trans-unit id="unsupportedTransport.docs.linkText">
+				<source>official documentation</source>
+			</trans-unit>
+			<trans-unit id="unsupportedTransport.example.header">
+				<source>Example configuration</source>
+			</trans-unit>
+
 			<trans-unit id="modal.failureDetails.header">
 				<source>Transport failure details</source>
 			</trans-unit>

--- a/Resources/Private/Partials/List/UnsupportedTransport.html
+++ b/Resources/Private/Partials/List/UnsupportedTransport.html
@@ -1,0 +1,50 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+      xmlns:c="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
+      data-namespace-typo3-fluid="true">
+
+<f:be.infobox state="2"
+              title="{f:translate(key: 'alert.unsupportedTransport.title', extensionName: 'Mailqueue')}"
+              message="{f:translate(key: 'alert.unsupportedTransport.message', arguments: '{0: transport}', extensionName: 'Mailqueue')}"
+/>
+
+<f:variable name="docsLink"><f:spaceless>
+    <a href="https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/Mail/Index.html#spooling"
+       target="_blank"
+       rel="noreferrer"
+    >{f:translate(key: 'unsupportedTransport.docs.linkText', extensionName: 'Mailqueue')}</a>
+</f:spaceless></f:variable>
+
+<p>
+    {f:translate(key: 'unsupportedTransport.docs.text', extensionName: 'Mailqueue', arguments: '{0: docsLink}') -> f:format.raw()}
+</p>
+
+<div class="card">
+    <div class="card-header">
+        <div class="card-icon">
+            <c:icon identifier="actions-file-edit" />
+        </div>
+        <div class="card-header-body">
+            <h2 class="card-title">{f:translate(key: 'unsupportedTransport.example.header', extensionName: 'Mailqueue')}</h2>
+        </div>
+    </div>
+    <div class="card-body">
+        <pre><code><f:spaceless>
+$GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_spool_type'] = 'file';
+$GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_spool_filepath'] = '/path/to/mailqueue';
+        </f:spaceless></code></pre>
+    </div>
+    <div class="card-footer">
+        <f:if condition="{typo3Version} >= 12">
+            <f:then>
+                <code>config/system/additional.php</code>
+            </f:then>
+            <f:else>
+                <f:comment><!-- @todo Remove once support for TYPO3 v11 is dropped --></f:comment>
+                <code>typo3conf/AdditionalConfiguration.php</code>
+            </f:else>
+        </f:if>
+    </div>
+</div>
+
+
+</html>

--- a/Resources/Private/Templates/List.html
+++ b/Resources/Private/Templates/List.html
@@ -8,10 +8,10 @@
 
     <f:if condition="{unsupportedTransport}">
         <f:then>
-            <f:be.infobox state="2"
-                          title="{f:translate(key: 'alert.unsupportedTransport.title', extensionName: 'Mailqueue')}"
-                          message="{f:translate(key: 'alert.unsupportedTransport.message', arguments: '{0: unsupportedTransport}', extensionName: 'Mailqueue')}"
-            />
+            <f:render partial="List/UnsupportedTransport" arguments="{
+                transport: unsupportedTransport,
+                typo3Version: typo3Version
+            }" />
         </f:then>
         <f:else>
             <f:render partial="List/Queue" arguments="{


### PR DESCRIPTION
This PR adds an additional notice and configuration example in the backend module in case an unsupported transport is configured.