### PR TITLE
[FEATURE] Allow configuration of queue delay threshold

### DIFF
--- a/Classes/Configuration/ExtensionConfiguration.php
+++ b/Classes/Configuration/ExtensionConfiguration.php
@@ -34,12 +34,34 @@ use TYPO3\CMS\Core;
  */
 final class ExtensionConfiguration
 {
+    private const DEFAULT_DELAY_THRESHOLD = 1800;
     private const DEFAULT_ITEMS_PER_PAGE = 20;
 
     public function __construct(
         private readonly Core\Configuration\ExtensionConfiguration $configuration,
     ) {}
 
+    /**
+     * @return positive-int
+     */
+    public function getQueueDelayThreshold(): int
+    {
+        try {
+            $delayThreshold = $this->configuration->get(Extension::KEY, 'queue/delayThreshold');
+        } catch (Core\Exception) {
+            return self::DEFAULT_DELAY_THRESHOLD;
+        }
+
+        if (!is_scalar($delayThreshold)) {
+            return self::DEFAULT_DELAY_THRESHOLD;
+        }
+
+        return max(1, (int)$delayThreshold);
+    }
+
+    /**
+     * @return positive-int
+     */
     public function getItemsPerPage(): int
     {
         try {

--- a/Classes/Controller/MailqueueModuleController.php
+++ b/Classes/Controller/MailqueueModuleController.php
@@ -99,6 +99,7 @@ final class MailqueueModuleController
 
     /**
      * @return array{
+     *     delayThreshold: positive-int,
      *     failing: bool,
      *     longestPendingInterval: non-negative-int,
      *     pagination: Core\Pagination\SimplePagination,
@@ -140,6 +141,7 @@ final class MailqueueModuleController
         $pagination = new Core\Pagination\SimplePagination($paginator);
 
         return [
+            'delayThreshold' => $this->extensionConfiguration->getQueueDelayThreshold(),
             'failing' => $failing,
             'longestPendingInterval' => $longestPendingInterval,
             'pagination' => $pagination,

--- a/README.md
+++ b/README.md
@@ -183,9 +183,10 @@ $GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_spool_type'] = \Vendor\Extension\
 
 The following extension configuration options are available:
 
-| Configuration key             | Description                                                    | Required | Default |
-|-------------------------------|----------------------------------------------------------------|----------|---------|
-| **`pagination.itemsPerPage`** | Number of mails to display on a single page in backend module  | –        | `20`    |
+| Configuration key             | Description                                                               | Required | Default |
+|-------------------------------|---------------------------------------------------------------------------|----------|---------|
+| **`queue.delayThreshold`**    | Number in seconds after which a mail in the queue is considered "delayed" | –        | `1800`  |
+| **`pagination.itemsPerPage`** | Number of mails to display on a single page in backend module             | –        | `20`    |
 
 ## 🧑‍💻 Contributing
 

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -62,7 +62,7 @@
 				<source>At least one mail could not be sent. You may check your mail transport and verify if everything works as intended.</source>
 			</trans-unit>
 			<trans-unit id="alert.stuckTransport.message">
-				<source>It seems like some mails were not sent for at least 30 minutes. Make sure to periodically flush the mail queue.</source>
+				<source>It seems like some mails have been in the queue for some time. Make sure to periodically flush the mail queue.</source>
 			</trans-unit>
 			<trans-unit id="alert.noIssues.message">
 				<source>The mail queue seems to be healthy. Make sure to periodically flush it.</source>

--- a/Resources/Private/Partials/List/Queue.html
+++ b/Resources/Private/Partials/List/Queue.html
@@ -32,12 +32,12 @@
                           message="{f:translate(key: 'alert.failedTransports.message', extensionName: 'Mailqueue')}"
             />
         </f:if>
-        <f:if condition="{longestPendingInterval} > 1800">
+        <f:if condition="{longestPendingInterval} > {delayThreshold}">
             <f:be.infobox state="1"
                           message="{f:translate(key: 'alert.stuckTransport.message', extensionName: 'Mailqueue')}"
             />
         </f:if>
-        <f:if condition="!{failing} && {longestPendingInterval} < 1800">
+        <f:if condition="!{failing} && {longestPendingInterval} < {delayThreshold}">
             <f:be.infobox state="0"
                           message="{f:translate(key: 'alert.noIssues.message', extensionName: 'Mailqueue')}"
             />

--- a/Resources/Private/Partials/List/QueueItem.html
+++ b/Resources/Private/Partials/List/QueueItem.html
@@ -14,7 +14,7 @@
                 </f:if>
             </f:case>
             <f:case value="queued">
-                <f:if condition="{queueItem.date} && {queueItem.date -> m:dateInterval()} >= 1800">
+                <f:if condition="{queueItem.date} && {queueItem.date -> m:dateInterval()} >= {delayThreshold}">
                     <f:then>
                         <span class="badge badge-warning d-block">{f:translate(key: 'queueItem.state.late', extensionName: 'Mailqueue')}</span>
                     </f:then>
@@ -24,7 +24,7 @@
                 </f:if>
             </f:case>
             <f:case value="sending">
-                <f:if condition="{queueItem.date} && {queueItem.date -> m:dateInterval()} >= 1800">
+                <f:if condition="{queueItem.date} && {queueItem.date -> m:dateInterval()} >= {delayThreshold}">
                     <f:then>
                         <span class="badge badge-warning d-block">{f:translate(key: 'queueItem.state.late', extensionName: 'Mailqueue')}</span>
                     </f:then>
@@ -86,7 +86,7 @@
 
 <f:section name="rowClass">
     <f:switch expression="{state.value}">
-        <f:case value="queued"><f:if condition="{date} && {date -> m:dateInterval()} >= 1800">warning</f:if></f:case>
+        <f:case value="queued"><f:if condition="{date} && {date -> m:dateInterval()} >= {delayThreshold}">warning</f:if></f:case>
         <f:case value="failed">danger</f:case>
         <f:case value="sending">warning</f:case>
     </f:switch>

--- a/Resources/Private/Templates/List.html
+++ b/Resources/Private/Templates/List.html
@@ -15,6 +15,7 @@
         </f:then>
         <f:else>
             <f:render partial="List/Queue" arguments="{
+                delayThreshold: delayThreshold,
                 failing: failing,
                 longestPendingInterval: longestPendingInterval,
                 pagination: pagination,

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,2 +1,5 @@
+# cat=queue//10; type=int+; label=Number in seconds after which a mail in the queue is considered "delayed"
+queue.delayThreshold = 1800
+
 # cat=pagination//10; type=int+; label=Number of mails to display on a single page in backend module list pagination
 pagination.itemsPerPage = 20


### PR DESCRIPTION
This PR adds a new extension configuration that allows to configure the queue delay threshold. By default, it is set to 1800 seconds (30 minutes).