### PR TITLE
[TASK] Prevent visible mismatch between TYPO3 versions

### DIFF
--- a/Resources/Private/Partials/List/UnsupportedTransport.html
+++ b/Resources/Private/Partials/List/UnsupportedTransport.html
@@ -28,10 +28,10 @@
         </div>
     </div>
     <div class="card-body">
-        <pre><code><f:spaceless>
+        <pre><f:spaceless>
 $GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_spool_type'] = 'file';
 $GLOBALS['TYPO3_CONF_VARS']['MAIL']['transport_spool_filepath'] = '/path/to/mailqueue';
-        </f:spaceless></code></pre>
+        </f:spaceless></pre>
     </div>
     <div class="card-footer">
         <f:if condition="{typo3Version} >= 12">


### PR DESCRIPTION
This PR removes a `<code>` tag to avoid a visible mismatch between TYPO3 versions.