### PR TITLE
[!!!][FEATURE] Allow to delete enqueued mails

### DIFF
--- a/Classes/Mail/Transport/QueueableFileTransport.php
+++ b/Classes/Mail/Transport/QueueableFileTransport.php
@@ -166,6 +166,24 @@ final class QueueableFileTransport extends Core\Mail\FileSpool implements Recove
         return true;
     }
 
+    public function delete(Mail\Queue\MailQueueItem $item): bool
+    {
+        $path = $this->path . DIRECTORY_SEPARATOR . $item->id;
+        $failurePath = $this->getFileVariant($path, self::FILE_SUFFIX_FAILURE_DATA);
+
+        // Early return if message no longer exists in queue
+        if (!file_exists($path)) {
+            return false;
+        }
+
+        // Remove failure metadata
+        if (file_exists($failurePath)) {
+            unlink($failurePath);
+        }
+
+        return unlink($path);
+    }
+
     public function getMailQueue(): Mail\Queue\MailQueue
     {
         return new Mail\Queue\MailQueue(

--- a/Classes/Mail/Transport/QueueableMemoryTransport.php
+++ b/Classes/Mail/Transport/QueueableMemoryTransport.php
@@ -66,6 +66,17 @@ final class QueueableMemoryTransport extends Core\Mail\MemorySpool implements Qu
         return true;
     }
 
+    public function delete(Mail\Queue\MailQueueItem $item): bool
+    {
+        if (!isset($this->queuedMessages[$item->id])) {
+            return false;
+        }
+
+        unset($this->queuedMessages[$item->id]);
+
+        return true;
+    }
+
     public function getMailQueue(): Mail\Queue\MailQueue
     {
         return new Mail\Queue\MailQueue(

--- a/Classes/Mail/Transport/QueueableTransport.php
+++ b/Classes/Mail/Transport/QueueableTransport.php
@@ -47,4 +47,6 @@ interface QueueableTransport extends Core\Mail\DelayedTransportInterface
      * @throws Mailer\Exception\TransportExceptionInterface
      */
     public function dequeue(Mail\Queue\MailQueueItem $item, Mailer\Transport\TransportInterface $transport): bool;
+
+    public function delete(Mail\Queue\MailQueueItem $item): bool;
 }

--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ methods to enqueue and dequeue mails:
   with the difference that it only dequeues the given mail queue item and leaves the
   rest of the queue untouched.
 
+* ```php
+  public function delete(Mail\Queue\MailQueueItem $item): bool
+  ```
+  Deletes the message of a given mail queue item without sending it. The message is
+  also dequeued from the mail queue.
+
 #### Recoverable transports
 
 Next to the `QueueableTransport` interface there exists an extended interface

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -79,6 +79,9 @@
 			<trans-unit id="alert.sendResult.sent.message">
 				<source>The mail was successfully sent.</source>
 			</trans-unit>
+			<trans-unit id="alert.deleteResult.deleted.message">
+				<source>The mail was successfully deleted.</source>
+			</trans-unit>
 
 			<trans-unit id="unsupportedTransport.docs.text">
 				<source>Read the %s to learn more about mail spoolers in TYPO3.</source>
@@ -92,6 +95,12 @@
 
 			<trans-unit id="modal.failureDetails.header">
 				<source>Transport failure details</source>
+			</trans-unit>
+			<trans-unit id="modal.delete.header">
+				<source>Delete this mail?</source>
+			</trans-unit>
+			<trans-unit id="modal.delete.text">
+				<source>Are you sure you want to delete '%s'?</source>
 			</trans-unit>
 
 			<trans-unit id="humanDate.now">
@@ -149,6 +158,12 @@
 			</trans-unit>
 			<trans-unit id="button.config">
 				<source>View mail configuration</source>
+			</trans-unit>
+			<trans-unit id="button.delete">
+				<source>Delete mail</source>
+			</trans-unit>
+			<trans-unit id="button.cancel">
+				<source>Cancel</source>
 			</trans-unit>
 
 			<trans-unit id="pagination.paginatedItems">

--- a/Resources/Private/Partials/List/Queue.html
+++ b/Resources/Private/Partials/List/Queue.html
@@ -3,6 +3,12 @@
 
 {queue -> f:count() -> f:variable(name: 'count')}
 
+<f:if condition="{deleteResult}">
+    <f:be.infobox state="0"
+                  message="{f:translate(key: 'alert.deleteResult.deleted.message', extensionName: 'Mailqueue')}"
+    />
+</f:if>
+
 <f:if condition="{sendResult}">
     <f:switch expression="{sendResult.value}">
         <f:case value="alreadySent">

--- a/Resources/Private/Partials/List/QueueItem.html
+++ b/Resources/Private/Partials/List/QueueItem.html
@@ -5,6 +5,8 @@
 
 <tr class="{f:render(section: 'rowClass', arguments: {state: queueItem.state, date: queueItem.date}) -> f:spaceless()}">
     <td class="col-icon align-top">
+        <f:render partial="Modal/ConfirmDelete" arguments="{queueItem: queueItem, iterator: iterator}" />
+
         <f:switch expression="{queueItem.state.value}">
             <f:case value="failed">
                 <span class="badge badge-danger d-block">{f:translate(key: 'queueItem.state.failed', extensionName: 'Mailqueue')}</span>
@@ -68,12 +70,19 @@
         <div class="btn-group">
             <f:if condition="{queueItem.state.value} == 'failed' && {queueItem.failure}">
                 <button type="button" class="btn btn-default btn-sm" data-bs-toggle="modal"
-                        data-bs-target="#queue-item-{iterator.cycle}-modal"
+                        data-bs-target="#queue-item-{iterator.cycle}-info-modal"
                         title="{f:translate(key: 'button.info', extensionName: 'Mailqueue')}"
                 >
                     <c:icon identifier="actions-info" />
                 </button>
             </f:if>
+
+            <button type="button" class="btn btn-default btn-sm" data-bs-toggle="modal"
+                    data-bs-target="#queue-item-{iterator.cycle}-delete-modal"
+                    title="{f:translate(key: 'button.delete', extensionName: 'Mailqueue')}"
+            >
+                <c:icon identifier="actions-delete" />
+            </button>
 
             <f:be.link route="system_mailqueue" parameters="{send: queueItem.id}" class="btn btn-default btn-sm"
                        title="{f:translate(key: 'button.send', extensionName: 'Mailqueue')}"

--- a/Resources/Private/Partials/Modal/ConfirmDelete.html
+++ b/Resources/Private/Partials/Modal/ConfirmDelete.html
@@ -1,0 +1,40 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+      xmlns:c="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
+      data-namespace-typo3-fluid="true">
+
+<div id="queue-item-{iterator.cycle}-delete-modal"
+         class="modal fade modal-severity-warning modal-style-default modal-size-default text-start"
+         tabindex="-1"
+         aria-modal="true"
+         role="dialog"
+>
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h4 class="modal-title">{f:translate(key: 'modal.delete.header', extensionName: 'Mailqueue')}</h4>
+                <button type="button" class="close" data-bs-dismiss="modal">
+                    <c:icon identifier="actions-close" size="small" />
+                    <span class="visually-hidden">{f:translate(key: 'aria.close', extensionName: 'Mailqueue')}</span>
+                </button>
+            </div>
+            <div class="modal-body nowrap-disabled">
+                <p>
+                    <f:translate key="modal.delete.text" extensionName="Mailqueue" arguments="{
+                        0: '{f:if(condition: queueItem.message.message.subject, then: queueItem.message.message.subject, else: queueItem.message.originalMessage.subject)}'
+                    }" />
+                </p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-bs-dismiss="modal">
+                    <f:translate key="button.cancel" extensionName="Mailqueue" />
+                </button>
+
+                <f:be.link route="system_mailqueue" parameters="{delete: queueItem.id}" class="btn btn-warning">
+                    <f:translate key="button.delete" extensionName="Mailqueue" />
+                </f:be.link>
+            </div>
+        </div>
+    </div>
+</div>
+
+</html>

--- a/Resources/Private/Partials/Modal/TransportFailureDetails.html
+++ b/Resources/Private/Partials/Modal/TransportFailureDetails.html
@@ -2,7 +2,7 @@
       xmlns:c="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
       data-namespace-typo3-fluid="true">
 
-<div id="queue-item-{iterator.cycle}-modal"
+<div id="queue-item-{iterator.cycle}-info-modal"
          class="modal fade modal-severity-danger modal-style-default modal-size-default text-start"
          tabindex="-1"
          aria-modal="true"

--- a/Resources/Private/Templates/List.html
+++ b/Resources/Private/Templates/List.html
@@ -16,6 +16,7 @@
         <f:else>
             <f:render partial="List/Queue" arguments="{
                 delayThreshold: delayThreshold,
+                deleteResult: deleteResult,
                 failing: failing,
                 longestPendingInterval: longestPendingInterval,
                 pagination: pagination,


### PR DESCRIPTION
This PR extends the `QueueableTransport` interface by a `delete()` method. It allows to delete a single mail without sending it. This feature is also added to the backend module.