### PR TITLE
[BUGFIX] Consider actual timezone when dealing with mail queue items

### DIFF
--- a/Classes/Controller/MailqueueModuleController.php
+++ b/Classes/Controller/MailqueueModuleController.php
@@ -52,6 +52,7 @@ final class MailqueueModuleController
         private readonly Backend\Template\ModuleTemplateFactory $moduleTemplateFactory,
         private readonly Core\Mail\Mailer $mailer,
         private readonly Backend\Routing\UriBuilder $uriBuilder,
+        private readonly Core\Context\Context $context,
     ) {
         $this->typo3Version = new Core\Information\Typo3Version();
     }
@@ -118,7 +119,8 @@ final class MailqueueModuleController
     ): array {
         $failing = false;
         $longestPendingInterval = 0;
-        $now = time();
+        /** @var int $now */
+        $now = $this->context->getPropertyFromAspect('date', 'timestamp');
         $sendResult = null;
         $deleteResult = false;
 

--- a/Classes/Mail/Transport/QueueableFileTransport.php
+++ b/Classes/Mail/Transport/QueueableFileTransport.php
@@ -28,6 +28,8 @@ use CPSIT\Typo3Mailqueue\Exception;
 use CPSIT\Typo3Mailqueue\Iterator;
 use CPSIT\Typo3Mailqueue\Mail;
 use DateTimeImmutable;
+use DateTimeInterface;
+use DateTimeZone;
 use DirectoryIterator;
 use Generator;
 use Psr\Log;
@@ -256,7 +258,7 @@ final class QueueableFileTransport extends Core\Mail\FileSpool implements Recove
 
         // Add last modification date
         if ($lastChanged !== false) {
-            $date = new DateTimeImmutable('@' . $lastChanged);
+            $date = new DateTimeImmutable('@' . $lastChanged, $this->getCurrentTimezone());
         } else {
             $date = null;
         }
@@ -293,5 +295,16 @@ final class QueueableFileTransport extends Core\Mail\FileSpool implements Recove
         }
 
         return $file;
+    }
+
+    private function getCurrentTimezone(): ?DateTimeZone
+    {
+        $date = $this->context->getPropertyFromAspect('date', 'full');
+
+        if (!($date instanceof DateTimeInterface)) {
+            return null;
+        }
+
+        return $date->getTimezone();
     }
 }

--- a/Classes/ViewHelpers/DateIntervalViewHelper.php
+++ b/Classes/ViewHelpers/DateIntervalViewHelper.php
@@ -25,6 +25,7 @@ namespace CPSIT\Typo3Mailqueue\ViewHelpers;
 
 use Closure;
 use DateTimeInterface;
+use TYPO3\CMS\Core;
 use TYPO3Fluid\Fluid;
 
 /**
@@ -48,11 +49,13 @@ final class DateIntervalViewHelper extends Fluid\Core\ViewHelper\AbstractViewHel
         Fluid\Core\Rendering\RenderingContextInterface $renderingContext,
     ): ?int {
         $date = $renderChildrenClosure();
+        /** @var int $now */
+        $now = Core\Utility\GeneralUtility::makeInstance(Core\Context\Context::class)->getPropertyFromAspect('date', 'timestamp');
 
         if (!($date instanceof DateTimeInterface)) {
             return null;
         }
 
-        return time() - $date->getTimestamp();
+        return $now - $date->getTimestamp();
     }
 }


### PR DESCRIPTION
This PR considers the actual timezone when creating and comparing dates of mail queue items. This is especially useful to properly identify late pending mail queue items.