### PR TITLE
[TASK] Deliver Crowdin sources using a dedicated workflow

### DIFF
--- a/.crowdin.yaml
+++ b/.crowdin.yaml
@@ -1,3 +1,5 @@
 files:
-  - source: /Resources/Private/Language/
+  - source: /Resources/Private/Language/locallang.xlf
+    translation: /%original_path%/%two_letters_code%.%original_file_name%
+  - source: /Resources/Private/Language/locallang*.xlf
     translation: /%original_path%/%two_letters_code%.%original_file_name%

--- a/.github/workflows/crowdin.yaml
+++ b/.github/workflows/crowdin.yaml
@@ -1,0 +1,21 @@
+name: Crowdin
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  sync:
+    name: Synchronize with Crowdin
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Upload sources
+        uses: crowdin/github-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+        with:
+          config: '.crowdin.yaml'


### PR DESCRIPTION
Crowdin sources are now synchronized using a dedicated GitHub workflow.